### PR TITLE
feat: could set context name when add a new kubeconfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ kconf add /path/to/kubeconfig.conf
 or
 
 ```sh
-kconf add /path/to/kubeconfig.conf context_name
+kconf add /path/to/kubeconfig.conf --contextName=name
+kconf add /path/to/kubeconfig.conf -n=name
 ```
 
 To remove an existing kubeconfig:

--- a/README.md
+++ b/README.md
@@ -1,37 +1,55 @@
 # kconf
+
 An opinionated command line tool for managing multiple kubeconfigs.
 
 ## Description
+
 kconf works by storing all kubeconfig information in a single file (`$HOME/.kube/config`). This file is looked at by default when using `kubectl`.
 
 ## Usage
+
 To merge in a new kubeconfig file:
+
 ```sh
 kconf add /path/to/kubeconfig.conf
 ```
+
+or
+
+```sh
+kconf add /path/to/kubeconfig.conf context_name
+```
+
 To remove an existing kubeconfig:
+
 ```sh
 kconf rm myContext
 ```
 
 To view all saved contexts in the kubeconfig:
+
 ```sh
 kconf list
 ```
 
 To view and print a single context's kubeconfig (you can pipe or export to a file):
+
 ```sh
 kconf view myContext
 ```
 
 ## Why?
+
 I was previously managing my kubeconfigs using the `$KUBECONFIG` environment variable. However, in order to automate this process, you have to do something like this in your rc files:
+
 ```bash
 KUBECONFIG=$(find $HOME/.kube -type f -name '*.conf' 2> /dev/null | sed ':a;N;$!ba;s/\n/:/g')
 ```
+
 ... that gets you a `$KUBECONFIG` variable with all your kubeconfigs separated by colons. The problem is that if you're frequently working with new/modified kubeconfigs, you'd have to trigger this command each time something changed.
 
 With the `kconf` command, there's no need for `$KUBECONFIG` since `kubectl` already looks at `$HOME/.kube/config` by default. Additionally, as soon as you have a new kubeconfig, you can `add` it pretty easily and quickly.
 
 ## Known Issues
+
 Check out the [Issues](https://github.com/particledecay/kconf/issues) section or specifically [issues created by me](https://github.com/particledecay/kconf/issues?q=is:issue+is:open+sort:updated-desc+author:particledecay)

--- a/cmd/kconf.go
+++ b/cmd/kconf.go
@@ -37,8 +37,8 @@ var rootCmd = &cobra.Command{
 
 var addCmd = &cobra.Command{
 	Use:   "add",
-	Short: "Add in a new kubeconfig file could set context name",
-	Long:  `Add a new kubeconfig file to the existing merged config file and set context name`,
+	Short: "Add in a new kubeconfig file and option context name",
+	Long:  `Add a new kubeconfig file to the existing merged config file and option context name`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("You must supply the path to a kubeconfig file")
@@ -111,9 +111,13 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal().Msgf("Could not read main config")
 		}
-		contexts := config.List()
+		contexts, currentContext := config.List()
 		for _, ctx := range contexts {
-			fmt.Println(ctx)
+			if currentContext == ctx {
+				fmt.Println("*", ctx)
+			} else {
+				fmt.Println(" ", ctx)
+			}
 		}
 	},
 }

--- a/cmd/kconf.go
+++ b/cmd/kconf.go
@@ -37,8 +37,8 @@ var rootCmd = &cobra.Command{
 
 var addCmd = &cobra.Command{
 	Use:   "add",
-	Short: "Add in a new kubeconfig file",
-	Long:  `Add a new kubeconfig file to the existing merged config file`,
+	Short: "Add in a new kubeconfig file could set context name",
+	Long:  `Add a new kubeconfig file to the existing merged config file and set context name`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("You must supply the path to a kubeconfig file")
@@ -47,6 +47,10 @@ var addCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		filepath := args[0]
+		name := ""
+		if len(args) == 2 {
+			name = args[1]
+		}
 		config, err := kubeconfig.GetConfig()
 		if err != nil {
 			log.Fatal().Msgf("Error while reading main config: %v", err)
@@ -60,7 +64,7 @@ var addCmd = &cobra.Command{
 			log.Fatal().Msgf("Could not find kubeconfig at %s", filepath)
 		}
 
-		err = config.Merge(newConfig)
+		err = config.Merge(newConfig, name)
 		if err != nil {
 			log.Fatal().Msgf("%v", err)
 		}

--- a/cmd/kconf.go
+++ b/cmd/kconf.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	verbose bool
+	verbose     bool
+	contextName string
 )
 
 var rootCmd = &cobra.Command{
@@ -47,10 +48,6 @@ var addCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		filepath := args[0]
-		name := ""
-		if len(args) == 2 {
-			name = args[1]
-		}
 		config, err := kubeconfig.GetConfig()
 		if err != nil {
 			log.Fatal().Msgf("Error while reading main config: %v", err)
@@ -64,7 +61,7 @@ var addCmd = &cobra.Command{
 			log.Fatal().Msgf("Could not find kubeconfig at %s", filepath)
 		}
 
-		err = config.Merge(newConfig, name)
+		err = config.Merge(newConfig, contextName)
 		if err != nil {
 			log.Fatal().Msgf("%v", err)
 		}
@@ -147,6 +144,7 @@ var viewCmd = &cobra.Command{
 func init() {
 	// flags
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "display debug messages")
+	addCmd.Flags().StringVarP(&contextName, "contextName", "n", "", "set context name")
 }
 
 // Execute combines all of the available command functions

--- a/pkg/kubeconfig/kconf_test.go
+++ b/pkg/kubeconfig/kconf_test.go
@@ -186,6 +186,20 @@ var _ = Describe("Pkg/Kubeconfig/AddContext", func() {
 
 		Expect(k.Contexts["test-1"].Cluster).To(Equal("test-1"))
 	})
+
+	It("Should add a context with context name", func() {
+		context := &clientcmdapi.Context{
+			LocationOfOrigin: "/home/user/.kube/config",
+			Cluster:          "test-1",
+			AuthInfo:         "test",
+			Namespace:        "default",
+		}
+		k := mockConfig(0)
+		testName := "test"
+		result, err := k.AddContext(testName, context)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).To(Equal(testName))
+	})
 })
 
 var _ = Describe("Pkg/Kubeconfig/hasCluster", func() {

--- a/pkg/kubeconfig/read.go
+++ b/pkg/kubeconfig/read.go
@@ -44,11 +44,14 @@ func GetConfig() (*KConf, error) {
 
 // List returns an array of contexts
 func (k *KConf) List() []string {
+	currentContext := k.Config.CurrentContext
 	contexts := []string{}
 	for context := range k.Contexts {
+		if currentContext == context {
+			context = "- " + context
+		}
 		contexts = append(contexts, context)
 	}
-
 	sort.Strings(contexts)
 	return contexts
 }

--- a/pkg/kubeconfig/read.go
+++ b/pkg/kubeconfig/read.go
@@ -43,17 +43,14 @@ func GetConfig() (*KConf, error) {
 }
 
 // List returns an array of contexts
-func (k *KConf) List() []string {
+func (k *KConf) List() ([]string, string) {
 	currentContext := k.Config.CurrentContext
 	contexts := []string{}
 	for context := range k.Contexts {
-		if currentContext == context {
-			context = "- " + context
-		}
 		contexts = append(contexts, context)
 	}
 	sort.Strings(contexts)
-	return contexts
+	return contexts, currentContext
 }
 
 // Export returns a single context's config from a kubeconfig file

--- a/pkg/kubeconfig/read_test.go
+++ b/pkg/kubeconfig/read_test.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"fmt"
+	"sort"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,6 +16,18 @@ var _ = Describe("Pkg/Kubeconfig/Read", func() {
 
 		Expect(config).To(BeNil())
 		Expect(err).Should(HaveOccurred())
+	})
+})
+
+var _ = Describe("Pkg/Kubeconfig/List", func() {
+	It("Should return all context names", func() {
+		contexts := []string{}
+		k := mockConfig(3)
+		for context := range k.Contexts {
+			contexts = append(contexts, context)
+		}
+		sort.Strings(contexts)
+		Expect(contexts).To(Equal([]string{"test", "test-1", "test-2"}))
 	})
 })
 

--- a/pkg/kubeconfig/write.go
+++ b/pkg/kubeconfig/write.go
@@ -19,7 +19,7 @@ func (k *KConf) Save() error {
 }
 
 // Merge takes a config and combines it into a config file
-func (k *KConf) Merge(config *clientcmdapi.Config) error {
+func (k *KConf) Merge(config *clientcmdapi.Config, name string) error {
 	renamedClusters := make(map[string]string)
 	renamedUsers := make(map[string]string)
 
@@ -57,8 +57,10 @@ func (k *KConf) Merge(config *clientcmdapi.Config) error {
 		if renamed, ok := renamedUsers[ctx.AuthInfo]; ok {
 			ctx.AuthInfo = renamed
 		}
-
-		added, err := k.AddContext(ctxName, ctx)
+		if name == "" {
+			name = ctxName
+		}
+		added, err := k.AddContext(name, ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: bzd111 <zxc@gogogozxc.xyz>
could set context name when add a new kubeconfig file.
Usage:
`kconf add kube_config_file context_name`
