### PR TITLE
feat: add fish and bash completions

### DIFF
--- a/completions/bash/kconf_completions.bash
+++ b/completions/bash/kconf_completions.bash
@@ -1,0 +1,58 @@
+__bash_kconf_commands () {
+   echo add help list rm use version view
+}
+
+__contains_word () {
+    local w word=$1; shift
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+    done
+}
+
+__bash_kconf_complete_contexts () {
+   kconf list |tr -d '*[:blank:]' | tr -s '[:space:]'
+}
+
+__bash_kconf_complete () {
+   local cmd=${COMP_WORDS[COMP_CWORD]}
+   local i verb comps
+
+   for ((i=0; i < COMP_CWORD; i++)); do
+      if __contains_word "${COMP_WORDS[i]}" $(__bash_kconf_commands); then
+         verb=${COMP_WORDS[i]}
+         break
+      fi
+   done
+
+   if [[ -z $verb ]]; then
+      comps=$(__bash_kconf_commands)
+   else
+      case $verb in
+         add)
+            COMPREPLY=( $(compgen -o plusdirs -f -- "$cmd") )
+            return 0
+            ;;
+         help)
+            ;;
+         list)
+            ;;
+         rm)
+            comps=$(__bash_kconf_complete_contexts)
+            ;;
+         use)
+            comps=$(__bash_kconf_complete_contexts)
+            ;;
+         version)
+            ;;
+         view)
+            comps=$(__bash_kconf_complete_contexts)
+            ;;
+      esac
+   fi
+
+   COMPREPLY=( $(compgen -W "$comps" -- "$cmd") )
+   return 0
+
+}
+
+complete -F __bash_kconf_complete kconf

--- a/completions/fish/kconf_completions.fish
+++ b/completions/fish/kconf_completions.fish
@@ -1,0 +1,56 @@
+set -l kconf_commands add help list rm use version view
+
+function __fish_kconf_complete_contexts
+   kconf list | tr -d '*[:blank:]'
+end
+
+function __fish_kconf_complete_namespaces
+   set -l cmd (commandline -opc)
+   if [ (count $cmd) -lt 3 ]
+      return 1
+   end
+
+   kubectl --context=$cmd[3] get namespaces -o custom-columns=:metadata.name
+end
+
+complete -c kconf -n "not __fish_seen_subcommand_from $kconf_commands" \
+  -a "add" \
+  -d "Add in a new kubeconfig file and optional context name"
+complete -c kconf -n "not __fish_seen_subcommand_from $kconf_commands" \
+  -f \
+  -a "help" \
+  -d "Help about any command"
+complete -c kconf -n "not __fish_seen_subcommand_from $kconf_commands" \
+  -f \
+  -a "list" \
+  -d "Lists available contexts"
+complete -c kconf -n "not __fish_seen_subcommand_from $kconf_commands" \
+  -f \
+  -a "rm" \
+  -d "Remove a kubeconfig from main file"
+complete -c kconf -n "not __fish_seen_subcommand_from $kconf_commands" \
+  -f \
+  -a "use" \
+  -d "Set the current context"
+complete -c kconf -n "not __fish_seen_subcommand_from $kconf_commands" \
+  -f \
+  -a "version" \
+  -d "Print version"
+complete -c kconf -n "not __fish_seen_subcommand_from $kconf_commands" \
+  -f \
+  -a "view" \
+  -d "View a specific context's config"
+
+# use, view, and rm take context arguments
+complete -c kconf \
+  -f \
+  -n "__fish_seen_subcommand_from use view rm" \
+  -a "(__fish_kconf_complete_contexts)"
+
+# use allows a namespace option
+complete -c kconf \
+  -x \
+  -n "__fish_seen_subcommand_from use" \
+  -s "n" \
+  -a "(__fish_kconf_complete_namespaces)" \
+  -d "set a namespace to use"


### PR DESCRIPTION
add fish and bash completions

## What? (description)

Adds command completions for fish shell and bash.

## Why? (reasoning)

Long or poorly-remembered contexts are less of a problem when the machine does the hunting.

## Screenshots (if applicable)


## GitHub Issue (if applicable)
[closes #21]


## Acceptance
Check your PR for the following:

- [ ] you included tests
- [ ] you linted your code
- [ ] your PR has only one commit (interactive rebase!)
- [ ] your commit message follows Conventional Commit format
- [ ] you are not reducing the total test coverage
