### PR TITLE
add 'namespace' command for easy namespace switching

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -18,7 +18,6 @@ policies:
           - style
           - test
         scopes:
-          - "*"
           - cmd
           - pkg
           - build

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/particledecay/kconf/pkg/kubeconfig"
+)
+
+var namespaceCmd = &cobra.Command{
+	Use:     "namespace",
+	Short:   "Set preferred namespace",
+	Long:    `Set the preferred namespace within the current context`,
+	Aliases: []string{"ns"},
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("You must provide the name of a namespace within the current context")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		namespace := args[0]
+
+		config, err := kubeconfig.GetConfig()
+		if err != nil {
+			log.Fatal().Msgf("Could not read main config")
+		}
+
+		// fail if we have no current context
+		if config.CurrentContext == "" {
+			log.Fatal().Msgf("No current context detected. You must set one first with the `use` command.")
+		}
+
+		err = config.SetNamespace(config.CurrentContext, namespace)
+		if err != nil {
+			log.Fatal().Msgf("%v", err)
+		}
+		if namespace != "" {
+			fmt.Printf("Setting preferred namespace '%s'\n", namespace)
+		}
+
+		err = config.Save()
+		if err != nil {
+			log.Fatal().Msgf("%v", err)
+		}
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ func Execute() {
 	rootCmd.AddCommand(viewCmd)
 	rootCmd.AddCommand(useCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(namespaceCmd)
 	rootCmd.AddCommand(completionCmd)
 
 	completionCmd.AddCommand(completionBashCmd)


### PR DESCRIPTION
## What? (description)
Add a `namespace` command to quickly switch namespaces (and an alias `ns` to make it really easy for us uber lazy folks).

In order to switch namespaces (without having to specify the current context), you can do:

```bash
kconf ns mynamespace
```

...and it will set "mynamespace" as your preferred namespace within whatever the current context is.

## Why? (reasoning)
Well, ultimately I got tired of typing out `kconf use some-really-long-context-thats-already-the-current-context -n mynamespace`.

Also, I figured I could put another nail in the kubectx coffin. This project should really be able to handle all things config-related.


## GitHub Issue (if applicable)
[closes #25]


## Acceptance
Check your PR for the following:

- [ ] you included tests
- [x] you linted your code
- [x] your PR has only one commit (interactive rebase!)
- [x] your commit message follows Conventional Commit format
- [ ] you are not reducing the total test coverage