### PR TITLE
add namespace autocompletion

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -47,4 +47,12 @@ var namespaceCmd = &cobra.Command{
 			log.Fatal().Msgf("%v", err)
 		}
 	},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := getNamespacesFromConfig(toComplete)
+		if err != nil {
+			log.Fatal().Msgf("%v", err)
+		}
+
+		return list, cobra.ShellCompDirectiveNoFileComp
+	},
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
 	k8s.io/utils v0.0.0-20200109141947-94aeca20bf09 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/pkg/kubeconfig/client.go
+++ b/pkg/kubeconfig/client.go
@@ -1,0 +1,22 @@
+package kubeconfig
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetRestConfig returns a rest.Config from a KConf type
+func GetRestConfig(config *KConf) (*rest.Config, error) {
+	apiConfig := config.Config
+
+	// first get the DirectClientConfig
+	clientConfig := clientcmd.NewDefaultClientConfig(apiConfig, &clientcmd.ConfigOverrides{})
+
+	// get the rest.Config
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return restConfig, nil
+}


### PR DESCRIPTION
## What? (description)
Add autocompletion capabilities to the `namespace` command.

## Why? (reasoning)
Right now you can autocomplete available contexts. Namespaces would be the next logical step, though that involves the additional requirement of authenticating to the Kubernetes apiserver. Luckily, in order to switch namespaces you must already have a context enabled, so we should be able to use that context to communicate with the apiserver to retrieve namespaces.

## Acceptance
Check your PR for the following:

- [ ] you included tests
- [x] you linted your code
- [x] your PR has only one commit (interactive rebase!)
- [x] your commit message follows Conventional Commit format
- [ ] you are not reducing the total test coverage
