### PR TITLE
accept kubeconfigs from stdin

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/particledecay/kconf/pkg/kubeconfig"
+	kc "github.com/particledecay/kconf/pkg/kubeconfig"
 )
 
 // AddCmd merges a new kubeconfig into the existing kubeconfig file
@@ -19,22 +19,25 @@ func AddCmd() *cobra.Command {
 		Long:    `Add a new kubeconfig file to the existing merged config file and optional context name`,
 		Aliases: []string{"a"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 1 {
+			if len(args) < 1 && !kc.HasPipeData() {
 				return errors.New("you must supply the path to a kubeconfig file")
 			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			filepath := args[0]
-			config, err := kubeconfig.GetConfig()
+			config, err := kc.GetConfig()
 			if err != nil {
 				return err
 			}
 			if config == nil {
-				return fmt.Errorf("could not find kubeconfig at '%s'", filepath)
+				return fmt.Errorf("could not find kubeconfig at '%s'", kc.MainConfigPath)
 			}
 
-			newConfig, err := kubeconfig.Read(filepath)
+			filepath := ""
+			if !kc.HasPipeData() {
+				filepath = args[0]
+			}
+			newConfig, err := kc.Read(filepath)
 			if err != nil {
 				return err
 			}

--- a/pkg/kubeconfig/helpers.go
+++ b/pkg/kubeconfig/helpers.go
@@ -9,3 +9,9 @@ import (
 
 // for printing to stdout using zerolog
 var Out zerolog.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout, PartsExclude: []string{"time", "level"}})
+
+// HasPipeData returns true if kconf is receiving data from stdin pipe
+func HasPipeData() bool {
+	stat, _ := os.Stdin.Stat()
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}

--- a/pkg/kubeconfig/read.go
+++ b/pkg/kubeconfig/read.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sort"
 
@@ -12,7 +13,16 @@ import (
 
 // Read loads a kubeconfig file and returns an api.Config (client-go) type
 func Read(filepath string) (*clientcmdapi.Config, error) {
-	config, err := clientcmd.LoadFromFile(filepath)
+	var config *clientcmdapi.Config
+	var err error
+
+	if filepath == "" && HasPipeData() {
+		pipedData, _ := io.ReadAll(os.Stdin)
+		config, err = clientcmd.Load(pipedData)
+	} else {
+		config, err = clientcmd.LoadFromFile(filepath)
+	}
+
 	if err != nil {
 		log.Debug().
 			Err(err).


### PR DESCRIPTION
## What? (description)
In addition to the capability of reading kubeconfigs from a file, also
allow kubeconfigs to be passed directly to `kconf add` via stdin, such
as from a pipe.

## Why? (reasoning)
Because some kubeconfigs are stored somewhere other than a local filesystem, so it's valuable to accept either the file *or* the data itself.

## GitHub Issue (if applicable)
[closes #40]

## Acceptance
Check your PR for the following:

- [x] you included tests
- [x] you linted your code
- [x] your PR has only one commit (interactive rebase!)
- [x] your commit message follows Conventional Commit format
- [x] you are not reducing the total test coverage
