### PR TITLE
fix: updates how the context name is chosen when adding new contexts.…

### DIFF
--- a/pkg/kubeconfig/write.go
+++ b/pkg/kubeconfig/write.go
@@ -53,10 +53,16 @@ func (k *KConf) Merge(config *clientcmdapi.Config, name string) {
 		if renamed, ok := renamedUsers[ctx.AuthInfo]; ok {
 			ctx.AuthInfo = renamed
 		}
-		if name == "" {
-			name = ctxName
+		// the context name is chosen based on the following priority:
+		// 1. provided via --context-name
+		// 2. specified in the provided config file
+		// 3. generated from the cluster and user name (<cluster>-<user>)
+		if name != "" {
+			ctxName = name
+		} else if ctxName == "" && name == "" {
+			ctxName = fmt.Sprintf("%s-%s", ctx.Cluster, ctx.AuthInfo)
 		}
-		added := k.AddContext(name, ctx)
+		added := k.AddContext(ctxName, ctx)
 		if added != "" { // this context was newly added
 			if added != ctxName {
 				Out.Log().Msgf("renamed context '%s' to '%s'", ctxName, added)

--- a/pkg/kubeconfig/write_test.go
+++ b/pkg/kubeconfig/write_test.go
@@ -180,6 +180,22 @@ func TestMerge(t *testing.T) {
 			AssertContext(t, k, "test")
 			AssertContext(t, k, "test-1") // renamed context
 		},
+		"merge multiple unique contexts": func(t *testing.T) {
+			k := MockConfig(1)
+			k2 := MockConfig(3)
+
+			// we need k and k2 to be two unique configs, so delete the first config in k2
+			err := k2.Remove("test")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			k.Merge(&k2.Config, "")
+
+			AssertContext(t, k, "test")
+			AssertContext(t, k, "test-1")
+			AssertContext(t, k, "test-2")
+		},
 		"rename cluster if it already exists": func(t *testing.T) {
 			k := MockConfig(1)
 			k2 := MockConfig(2)


### PR DESCRIPTION
…Previously if more than one context was added, the first context would get the correct name but all additional contexts would be seen as duplicates of the first and renamed as such (refs #43).

<!-- type: lowercase summary of pull request (replace this line) -->

## What? (description)
If a context name is provided via the --context-name argument, all contexts added will use that name (myContext, myContext-1, etc.). If no context name is provided as an argument, then the context name from the config file provided will be used. If no context name is found in the config file, then a new name will be generated based on the cluster and user name used by the new context (i.e. myCluster-myUser).

## Why? (reasoning)
Currently if you add multiple contexts at the same time and do not specify a name via the --context-name argument, only the first context will be added with the correct name.

## Screenshots (if applicable)
N/A

## GitHub Issue (if applicable)
[closes #43]

## Acceptance
Check your PR for the following:

- [ ] you included tests
- [ ] you linted your code
- [ ] your PR has appropriate, atomic commits (interactive rebase!)
- [ ] your commit message follows Conventional Commit format
- [ ] you are not reducing the total test coverage
