### PR TITLE
feat: add makefile and switch to codacy

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,22 +16,15 @@ jobs:
         with:
           go-version: 1.18
           cache: true
-
       - name: Install dependencies
         run: |
           go mod vendor
       - name: Run tests
         run: |
-          go test -shuffle on -race -coverprofile coverage.out ./...
-      - name: Convert Go coverage to LCOV
-        uses: jandelgado/gcov2lcov-action@v1.0.0
+          make test
+      - name: Send test coverage to Codacy
+        uses: codacy/codacy-coverage-reporter-action@v1
         with:
-          infile: coverage.out
-          outfile: coverage.lcov
-      - name: CodeClimate
-        uses: paambaati/codeclimate-action@v2.6.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE }}
-        with:
-          coverageCommand: echo ""
-          coverageLocations: ./coverage.lcov:lcov
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.out
+          force-coverage-parser: go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,26 +1,18 @@
 ---
 name: tests
 
-on:
-  pull_request:
-    branches: [main]
+on: pull_request_target
 
 jobs:
-  # for conform
-  conformance:
+
+  authorize:
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - run: |
-          git fetch origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/heads/${{ github.event.pull_request.base.ref }}
-
-      - name: Conform
-        uses: talos-systems/conform@main
-        with:
-          args: enforce --commit-ref=refs/heads/${{ github.event.pull_request.base.ref }}
+      - run: "true"
 
   # for pre-commit
   pre-commit:
@@ -28,19 +20,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: actions/setup-python@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
           cache: true
       - run: |
-          go install github.com/mgechev/revive@latest
+          make install-golangci-lint
       - uses: pre-commit/action@v3.0.0
 
   unit-testing:
+    needs: authorize
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -48,22 +40,15 @@ jobs:
         with:
           go-version: 1.18
           cache: true
-
       - name: Install dependencies
         run: |
           go mod vendor
       - name: Run tests
         run: |
-          go test -shuffle on -race -coverprofile coverage.out ./...
-      - name: Convert Go coverage to LCOV
-        uses: jandelgado/gcov2lcov-action@v1.0.0
+          make test
+      - name: Send test coverage to Codacy
+        uses: codacy/codacy-coverage-reporter-action@v1
         with:
-          infile: coverage.out
-          outfile: coverage.lcov
-      - name: CodeClimate
-        uses: paambaati/codeclimate-action@v2.6.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE }}
-        with:
-          coverageCommand: echo ""
-          coverageLocations: ./coverage.lcov:lcov
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.out
+          force-coverage-parser: go

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: test coverage pre-commit dependencies install-golangci-lint install-pre-commit
+
+test:
+	go test ./... -shuffle on -race -coverprofile=coverage.out
+
+coverage: test
+	go tool cover -html=coverage.out
+
+pre-commit: dependencies
+	@pre-commit install
+
+dependencies: install-golangci-lint install-pre-commit
+
+install-golangci-lint:
+	@command -v golangci-lint >/dev/null 2>&1 || { \
+		echo "Installing golangci-lint..."; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.55.2; \
+	}
+
+install-pre-commit:
+	@command -v asdf >/dev/null 2>&1 && asdf plugin-add pre-commit || true
+	@command -v asdf >/dev/null 2>&1 && asdf install pre-commit || pip install pre-commit

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
   <p align="center">
     <a href="https://github.com/particledecay/kconf/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/particledecay/kconf"></a>
     <a href="https://github.com/particledecay/kconf/actions/workflows/coverage.yml"><img alt="Test Status" src="https://github.com/particledecay/kconf/actions/workflows/coverage.yml/badge.svg"></a>
-    <a href="https://codeclimate.com/github/particledecay/kconf/maintainability"><img src="https://api.codeclimate.com/v1/badges/dd1904e8f1f515bad0b5/maintainability" /></a>
-    <a href="https://codeclimate.com/github/particledecay/kconf/test_coverage"><img src="https://api.codeclimate.com/v1/badges/dd1904e8f1f515bad0b5/test_coverage" /></a>
+    <a href="https://app.codacy.com/gh/particledecay/kconf/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img src="https://app.codacy.com/project/badge/Grade/b60ca14a594e4c1baa4fcb063ff1f50b"/></a>
   </p>
 </p>
 


### PR DESCRIPTION
feat: switch to codacy

## What? (description)

Switch to Codacy from Code Climate.

## Why? (reasoning)

Codacy supports Go coverage directly so the config is simpler, and it has more features than Code Climate.

## Acceptance
Check your PR for the following:

- [ ] you included tests
- [x] you linted your code
- [x] your PR has appropriate, atomic commits (interactive rebase!)
- [x] your commit message follows Conventional Commit format
- [x] you are not reducing the total test coverage
