### PR TITLE
chore: remove a double quote from asset names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ archives:
     {{- tolower .Os }}-
     {{- if eq .Arch "amd64" }}x86_64
     {{- else }}{{ .Arch }}{{ end }}-
-    {{- .Version }}"
+    {{- .Version }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
<!-- type: lowercase summary of pull request (replace this line) -->

## What? (description)

Remove a double quote from the template of asset names.

## Why? (reasoning)

This double quote is apparently unnecessary.
GitHub Releases removes double quotes from asset names automatically, but asset names in checksum files still have double quotes so the checksum file was broken.

https://github.com/particledecay/kconf/releases/tag/v2.0.0

https://github.com/particledecay/kconf/releases/download/v2.0.0/checksums.txt

```
f14383eeb2adf19a86ec5041d48d5c0382f2e48a3dbe5a1e8c24f79d4352588e  kconf-darwin-arm64-2.0.0".tar.gz
128c581e6b2ce144313e09789cb31845276ca9359970b38e30c4fc7b4fed865e  kconf-darwin-x86_64-2.0.0".tar.gz
5b95c70f1d17a79e03df7e58e9de307d62798611306844b66c089d9cb6671a08  kconf-linux-386-2.0.0".tar.gz
78c9dab53fca764823947a1a4b1fa7acfdc79fba9fe915df2b1d36aa09b398a7  kconf-linux-arm64-2.0.0".tar.gz
2d5537b3e33beec59989cf87545f3e09bb2b007213925f9977bf741f4767cf31  kconf-linux-x86_64-2.0.0".tar.gz
72d9f30fc24c441c181309c5f8238fe25086236957e6d17160dee1d96c04bea1  kconf-windows-386-2.0.0".tar.gz
c1d8724d4ba3f6addd45492b8399046d3159842bfa5aa77c2c2c7aaed4d3a1ca  kconf-windows-arm64-2.0.0".tar.gz
0efc74d555dbe67d76bed1df064c84d8b51923c13779c66fc981d2dc7f6fafad  kconf-windows-x86_64-2.0.0".tar.gz
```

## Screenshots (if applicable)


## GitHub Issue (if applicable)

## Acceptance
Check your PR for the following:

- [ ] you included tests
- [ ] you linted your code
- [ ] your PR has appropriate, atomic commits (interactive rebase!)
- [ ] your commit message follows Conventional Commit format
- [ ] you are not reducing the total test coverage
