### PR TITLE
Feat add verify config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,7 @@ func Execute() {
 	root.AddCommand(VersionCmd())
 	root.AddCommand(NamespaceCmd())
 	root.AddCommand(RenameCmd())
+	root.AddCommand(VerifyCmd())
 
 	completion := CompletionCmd()
 	completion.AddCommand(completionBashCmd(root))

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	kc "github.com/particledecay/kconf/pkg/kubeconfig"
+)
+
+// VerifyCmd checks the provided kubeconfig file for errors
+func VerifyCmd() *cobra.Command {
+	command := &cobra.Command{
+		Use:     "verify",
+		Short:   "Check for errors in the provided kubeconfig file",
+		Long:    `Check the provided kubeconfig file for errors (contexts, clusters, users) and return any issues found`,
+		Aliases: []string{"vfy"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 && !kc.HasPipeData() {
+				return errors.New("you must supply the path to a kubeconfig file")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			filepath := ""
+			if !kc.HasPipeData() {
+				filepath = args[0]
+			}
+
+			config, err := kc.Read(filepath)
+			if err != nil {
+				return err
+			}
+
+			err = kc.ValidateConfig(config)
+			if err != nil {
+				kc.Out.Log().Msg("the following error(s) were found in the provided kubeconfig file:")
+				rgx := regexp.MustCompile(`(?m)\[(.*?)\]`)
+				for i, e := range strings.Split(rgx.FindStringSubmatch(err.Error())[1], ", ") {
+					kc.Out.Log().Msgf("%d. %s", i+1, string(e))
+				}
+			} else {
+				kc.Out.Log().Msg("no errors were found in the provided kubeconfig file")
+			}
+
+			return nil
+
+		},
+	}
+
+	return command
+}

--- a/pkg/kubeconfig/read.go
+++ b/pkg/kubeconfig/read.go
@@ -98,3 +98,8 @@ func (k *KConf) GetContent(name string) ([]byte, error) {
 
 	return content, nil
 }
+
+// ValidateConfig checks the provided kubeconfig file for errors
+func ValidateConfig(config *clientcmdapi.Config) error {
+	return clientcmd.Validate(*config)
+}


### PR DESCRIPTION
feat: add verify command to validate a provided kubeconfig file

## What? (description)
Adds a new command, verify, that validates a provided kubeconfig file.

## Why? (reasoning)
Provides a way to validate a new kubeconfig file before merging it in to your main kubeconfig file.

## Screenshots (if applicable)
N/A

## GitHub Issue (if applicable)
N/A

## Acceptance
Check your PR for the following:

- [x] you included tests
- [x] you linted your code
- [x] your PR has appropriate, atomic commits (interactive rebase!)
- [x] your commit message follows Conventional Commit format
- [x] you are not reducing the total test coverage
